### PR TITLE
Add comments for translators

### DIFF
--- a/data/application_id.appdata.xml.in
+++ b/data/application_id.appdata.xml.in
@@ -11,7 +11,7 @@
   <summary>A settings app for GNOME's Login Manager (GDM)</summary>
 
   <description>
-      <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
+     <!-- Translators: GDM is an acronym for GNOME Display Manager (which is also GNOME's Login Manager). -->
      <p>
         Change GDM Settings; Apply theme and background, change cursor theme, icon theme
         and night light settings, among other things.

--- a/data/application_id.appdata.xml.in
+++ b/data/application_id.appdata.xml.in
@@ -11,6 +11,7 @@
   <summary>A settings app for GNOME's Login Manager (GDM)</summary>
 
   <description>
+      <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
      <p>
         Change GDM Settings; Apply theme and background, change cursor theme, icon theme
         and night light settings, among other things.

--- a/data/gschemas/application_id.appearance.gschema.xml.in
+++ b/data/gschemas/application_id.appearance.gschema.xml.in
@@ -18,6 +18,7 @@
 	 <key name="background-type" type="s">
 	   <default>"None"</default>
 	   <summary>Type of Background</summary>
+	   <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
 	   <description>
 	     Wether GDM background should be an Image, Color or None.
 	   </description>
@@ -31,6 +32,7 @@
 	 <key name="background-image" type="s">
 	   <default>""</default>
 	   <summary>Background Image</summary>
+	   <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
 	   <description>
 	     The image file to use as GDM background
 	   </description>
@@ -39,6 +41,7 @@
 	 <key name="background-color" type="s">
 	   <default>"rgb(40,40,40)"</default>
 	   <summary>Background Color</summary>
+	   <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
 	   <description>
 	     The Color to use as GDM background
 	   </description>

--- a/data/gschemas/application_id.appearance.gschema.xml.in
+++ b/data/gschemas/application_id.appearance.gschema.xml.in
@@ -18,7 +18,7 @@
 	 <key name="background-type" type="s">
 	   <default>"None"</default>
 	   <summary>Type of Background</summary>
-	   <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
+      <!-- Translators: GDM is an acronym for GNOME Display Manager (which is also GNOME's Login Manager). -->
 	   <description>
 	     Wether GDM background should be an Image, Color or None.
 	   </description>
@@ -32,7 +32,7 @@
 	 <key name="background-image" type="s">
 	   <default>""</default>
 	   <summary>Background Image</summary>
-	   <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
+      <!-- Translators: GDM is an acronym for GNOME Display Manager (which is also GNOME's Login Manager). -->
 	   <description>
 	     The image file to use as GDM background
 	   </description>
@@ -41,7 +41,7 @@
 	 <key name="background-color" type="s">
 	   <default>"rgb(40,40,40)"</default>
 	   <summary>Background Color</summary>
-	   <!-- Translators: GDM is the acronym for GNOME Login Manager. -->
+      <!-- Translators: GDM is an acronym for GNOME Display Manager (which is also GNOME's Login Manager). -->
 	   <description>
 	     The Color to use as GDM background
 	   </description>

--- a/po/update-pot-file.sh
+++ b/po/update-pot-file.sh
@@ -5,5 +5,5 @@ cd "$progDir"/..
 POTFILES=(data{,/gschemas}/application_id.* src/*.py*)
 BLPFILES=(src/blueprints/*.blp*)
 rm -f "$pot_file"
-xgettext -o "$pot_file" "${POTFILES[@]}"
-xgettext -j -L Python -o "$pot_file" "${BLPFILES[@]}"
+xgettext --add-comments=Translators -o "$pot_file" "${POTFILES[@]}"
+xgettext --add-comments=Translators -j -L Python -o "$pot_file" "${BLPFILES[@]}"

--- a/po/update-pot-file.sh
+++ b/po/update-pot-file.sh
@@ -6,4 +6,4 @@ POTFILES=(data{,/gschemas}/application_id.* src/*.py*)
 BLPFILES=(src/blueprints/*.blp*)
 rm -f "$pot_file"
 xgettext --add-comments=Translators -o "$pot_file" "${POTFILES[@]}"
-xgettext --add-comments=Translators -j -L Python -o "$pot_file" "${BLPFILES[@]}"
+xgettext --add-comments=Translators -j -L ObjectiveC --from-code=UTF-8 -o "$pot_file" "${BLPFILES[@]}"

--- a/src/blueprints/display-page.blp
+++ b/src/blueprints/display-page.blp
@@ -47,6 +47,7 @@ ScrolledWindow display_page_content {
         Adw.ActionRow {
           title: _("Times");
 
+          // Translators: This is part of the timespan in which Night Light is active, e. g. "From 21:00 To 06:00".
           Label { label: _("From"); styles ["dim-label"] }
 
           Box night_light_start_box {
@@ -68,7 +69,7 @@ ScrolledWindow display_page_content {
           }
 
           Separator { styles ["spacer"] }
-          # Translators: This is part of the timespan in which Night Light is active, e. g. "21:00 to 06:00".
+          // Translators: This is part of the timespan in which Night Light is active, e. g. "From 21:00 To 06:00".
           Label { label: _("To"); styles ["dim-label"] }
 
           Box night_light_end_box{

--- a/src/blueprints/display-page.blp
+++ b/src/blueprints/display-page.blp
@@ -68,7 +68,7 @@ ScrolledWindow display_page_content {
           }
 
           Separator { styles ["spacer"] }
-
+          # Translators: This is part of the timespan in which Night Light is active, e. g. "21:00 to 06:00".
           Label { label: _("To"); styles ["dim-label"] }
 
           Box night_light_end_box{

--- a/src/gdm_settings_gui.py
+++ b/src/gdm_settings_gui.py
@@ -297,6 +297,7 @@ class GDM_Settings(Adw.Application, App_Utils):
         widgets.about_dialog.set_authors([dev_mazhar_hussain])
         widgets.about_dialog.set_artists([dev_mazhar_hussain])
         widgets.about_dialog.set_documenters([dev_mazhar_hussain])
+        # Translators: Do not translate this string. Put your info here in the form 'name <email>' including < and > but not qoutes.
         widgets.about_dialog.set_translator_credits(_("translator-credits"))
         # Font Scaling Factor SpinButton
         widgets.scaling_factor_spinbutton.set_range(0.5, 3)


### PR DESCRIPTION
This adds comments to the translation files, which should make it easier for new translators to get things right. Especially short strings without context, like `"To"`, are nearly untranslatable without further information.
BTW, I use KDE on my laptop, so I can only test this translation on my computer at home. I am on vacation at the moment, so I couldn't really test this. Have I got the comment about `"To"` right? If not, just change it - you can push to my branch ;)

For future comments: I noticed that in the `xml` files, the comment has to be outside the tags which enclose the text that needs translating:

```
<!-- Translators: This is the correct way to do it. -->
<p>
  Some translatable text.
</p>

<p>
  <!-- Translators: This is the wrong way to do it. -->
  Some translatable text.
</p>
```