### PR TITLE
Correct the summary and description in "night-light-end-hour" key

### DIFF
--- a/data/gschemas/io.github.realmazharhussain.GdmSettings.night-light.gschema.xml
+++ b/data/gschemas/io.github.realmazharhussain.GdmSettings.night-light.gschema.xml
@@ -36,8 +36,8 @@
 
     <key name="night-light-end-hour" type="i">
       <default>6</default>
-      <summary>The start time's hour</summary>
-      <description>When “night-light-schedule-automatic” is disabled, use this start time in hours.</description>
+      <summary>The end time's hour</summary>
+      <description>When “night-light-schedule-automatic” is disabled, use this end time in hours.</description>
       <range min="0" max="23"/>
     </key>
 


### PR DESCRIPTION
This corrects the summary and description texts in "night-light-end-hour" key, which seems to be a copy-and-paste error from "night-light-start-hour".
