### PR TITLE
Fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,9 +28,9 @@ body:
     validations:
       required: true
   - type: textarea
-    id: explaination
+    id: explanation
     attributes:
-      label: Detailed Explaination (Optional)
+      label: Detailed Explanation (Optional)
       description: Explain the problem in detail
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Explaination
-      description: Detailed Explaination (if required any)
+      label: Explanation
+      description: Detailed Explanation (if required any)
     validations:
       required: false

--- a/src/about.py
+++ b/src/about.py
@@ -25,6 +25,6 @@ def about_window(win):
         issue_url   = "https://github.com/realmazharhussain/gdm-settings/issues/new/choose",
 
         # Translators: Do not translate this string. Put your info here in the form
-        # 'name <email>' including < and > but not qoutes.
+        # 'name <email>' including < and > but not quotes.
         translator_credits = _("translator-credits"),
         )

--- a/src/app.py
+++ b/src/app.py
@@ -322,7 +322,7 @@ class Application(Adw.Application):
 
             message = _('Settings were successfully exported')
         except PermissionError:
-            message = _('Failed to export. Permssion denied')
+            message = _('Failed to export. Permission denied')
         except IsADirectoryError:
             message = _('Failed to export. A directory with that name already exists')
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -65,7 +65,7 @@ class ProcessReturnCode(int):
 class NoCommandsFoundError(Exception): pass
 
 class CommandElevator:
-    """ Runs a list of commands with elevated privilages """
+    """ Runs a list of commands with elevated privileges """
     def __init__(self, *, shebang='#!/bin/sh') -> None:
         self._list = []
         self.shebang = shebang

--- a/src/window.py
+++ b/src/window.py
@@ -142,7 +142,7 @@ class GdmSettingsWindow (Adw.ApplicationWindow):
         self.toast_overlay.add_toast(toast)
 
     def show_logout_dialog (self):
-        message = _('The system may start to look weird/buggy untill you re-login or reboot.')
+        message = _('The system may start to look weird/buggy until you re-login or reboot.')
 
         dialog = Adw.MessageDialog(
                     body = message,


### PR DESCRIPTION
Found via `codespell -S po -L ro,gir`