### PR TITLE
Updated copyright year

### DIFF
--- a/src/about.py
+++ b/src/about.py
@@ -14,7 +14,7 @@ def about_window(win):
         license_type     = Gtk.License.AGPL_3_0,
         version          = info.version,
         developer_name   = C_("Name of Developer", "Mazhar Hussain"),
-        copyright = _("Copyright 2021-2022 Mazhar Hussain"),
+        copyright = _("Copyright 2021-2023 Mazhar Hussain"),
         website   = "https://realmazharhussain.github.io/gdm-settings",
         developers  = [mazhar_hussain],
         designers   = [mazhar_hussain],

--- a/src/about.py
+++ b/src/about.py
@@ -14,7 +14,7 @@ def about_window(win):
         license_type     = Gtk.License.AGPL_3_0,
         version          = info.version,
         developer_name   = C_("Name of Developer", "Mazhar Hussain"),
-        copyright = _("Copyright 2021-2023 Mazhar Hussain"),
+        copyright = _("Copyright 2021–2023 Mazhar Hussain"),
         website   = "https://realmazharhussain.github.io/gdm-settings",
         developers  = [mazhar_hussain],
         designers   = [mazhar_hussain],


### PR DESCRIPTION
Would have fixed on Weblate if direct editing of source strings was turned on.
An "ignore-same" flag for https://hosted.weblate.org/translate/gdm-settings/language-names/en/?checksum=0837b26cdffae9b8 would also do nicely.