### PR TITLE
Avoid using machinectl, use su instead

### DIFF
--- a/gdms/settings.py
+++ b/gdms/settings.py
@@ -630,10 +630,9 @@ def apply_user_display_settings() -> bool:
     shutil.copyfile(user_monitors_xml, temp_monitors_xml)
     os.chmod(temp_monitors_xml, 0o644)
 
-    _commands.add(['machinectl', 'shell', f'{gresource.GdmUsername}@', '/usr/bin/env',
-                     'gsettings', 'set', 'org.gnome.mutter', 'experimental-features',
-                     '"[\'scale-monitor-framebuffer\']"',
-                     '&>/dev/null',
+    _commands.add(['su', f'{gresource.GdmUsername}',
+                     '-s', '/bin/sh',
+                     '-c', '"dbus-run-session gsettings set org.gnome.mutter experimental-features \\"[\'scale-monitor-framebuffer\']\\""'
                    ])
 
     _commands.add(['install', '-Dm644',


### PR DESCRIPTION
machinectl is unavailable on non-systemd-based systems like Alpine Linux or Chimera Linux. su is a alternative that works on all Unix systems.